### PR TITLE
move the relevant `improved_model` to device instead of the `model` from previous section

### DIFF
--- a/02_embedding_model.ipynb
+++ b/02_embedding_model.ipynb
@@ -1924,7 +1924,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/02_embedding_model.ipynb
+++ b/02_embedding_model.ipynb
@@ -1924,13 +1924,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "import torch\n",
     "device = torch.device(\"mps\" if torch.cuda.is_available() else \"cpu\")\n",
-    "model.to(device)\n",
+    "improved_model.to(device)\n",
     "minicorpus_docs = minicorpus_docs.to(device)"
    ]
   },


### PR DESCRIPTION
This causes an error when cuda is available since the actual model in the training isn't  on the cuda device.